### PR TITLE
Inline nav on laptop plz

### DIFF
--- a/src/components/ProfileHeader/index.js
+++ b/src/components/ProfileHeader/index.js
@@ -70,7 +70,7 @@ class ProfileHeader extends React.Component {
     );
 
     let viewsInline = false;
-    if (this.props.viewport.width >= 1500) {
+    if (this.props.viewport.width >= 1400) {
       viewsInline = true;
     }
 


### PR DESCRIPTION
I think a better solution here could be to detect when the nav overflows, and then toggle what nav to show based on that.  This is what I do on DestinySets.com https://github.com/joshhunt/destinySets/blob/master/src/components/Header/index.js#L171

But, this is just, IMHO, a more sensible value.